### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Satocash-Applet
-Open source javacard applet...
+
+Open source JavaCard applet for [Cashu](https://cashu.space) ecash.
 
 # Introduction
 
@@ -7,16 +8,15 @@ Open source javacard applet...
 
 # How to use your Satocash?
 
-
 # Supported hardware
 
 For supported hardware, refer to the [Satochip applet repository](https://github.com/Toporin/SatoChipApplet).
 
-# Buidl & install
+# Build & install
 
 ## Building using Ant (legacy)
 
-You can build the javacard CAP files or use the last [release](https://github.com/Toporin/Seedkeeper-Applet/releases).
+You can build the JavaCard CAP files or use the last [release](https://github.com/Toporin/Seedkeeper-Applet/releases).
 
 To generate the CAP file from the sources, you can use the [ant-javacard](https://github.com/martinpaljak/ant-javacard) Ant task (see the instructions on the ant-javacard github repository).
 
@@ -27,14 +27,15 @@ For detailed build and installation, refer to the [Satochip applet repository](h
 The project can also be built using Gradle with the [Fidesmo Javacard Gradle plugin](https://github.com/fidesmo/gradle-javacard).
 Using this approach allows to load the NDEF applet at the same time (allows to automatically open the right application on Android by simply tapping the card).
 
-For compiling the javacard code, you first need to download the javacard SDK into the project in the `sdks` folder:
+For compiling the JavaCard code, you first need to download the javacard SDK into the project in the `sdks` folder:
+
 ```
 git submodule add https://github.com/martinpaljak/oracle_javacard_sdks sdks
 ```
 
 Then you must set the JavaCard HOME. The gradle.properties file has a setting with the property "com.fidesmo.gradle.javacard.home" set to the correct path.
 
-To compile the javacard code and generate a cap file, simply run `./gradlew convertJavacard`. The cap file will be compiled in the `build/javacard/org/seedkeeper/applet` folder.
+To compile the JavaCard code and generate a cap file, simply run `./gradlew convertJavacard`. The cap file will be compiled in the `build/javacard/org/satocash/applet` folder.
 
 To load the cap file into a blank smart card, connect a card reader with the card inserted and run `./gradlew install`
 


### PR DESCRIPTION
fix minor typos in readme

the most important is that the path of the built applet is `build/javacard/org/satocash/applet` not `build/javacard/org/seedkeeper/applet`